### PR TITLE
added tests for public URL

### DIFF
--- a/spec/helpers/main-tests.js
+++ b/spec/helpers/main-tests.js
@@ -301,9 +301,34 @@ const mainTests = (baseConfig, baseExpectations, multiEntryConfig, multiEntryExp
     testPlugin(config, expected, done);
   });
 
+  it('copes with a URL public path', done => {
+    const config = baseConfig('one_stylesheet');
+    config.output.publicPath = 'https://www.github.com/wibble/';
+    const expected = baseExpectations();
+    expected.html = [
+      /<style>[\s\S]*background: snow;[\s\S]*<\/style>/
+    ];
+    testPlugin(config, expected, done);
+  });
+
   it('copes with a public path with specified css file', done => {
     const config = baseConfig('one_stylesheet');
     config.output.publicPath = '/wibble/';
+    config.plugins = [
+      new HtmlWebpackPlugin(),
+      new ExtractTextPlugin('styles.css'),
+      new StyleExtHtmlWebpackPlugin('styles.css')
+    ];
+    const expected = baseExpectations();
+    expected.html = [
+      /<style>[\s\S]*background: snow;[\s\S]*<\/style>/
+    ];
+    testPlugin(config, expected, done);
+  });
+
+  it('copes with a URL public path with specified css file', done => {
+    const config = baseConfig('one_stylesheet');
+    config.output.publicPath = 'https://www.github.com/wibble/';
     config.plugins = [
       new HtmlWebpackPlugin(),
       new ExtractTextPlugin('styles.css'),


### PR DESCRIPTION
Hi, I've added the tests for the fix.

Tests passes with your changes, and if these new tests run without your changes, the folowing failures occur:

```
**************************************************
*                    Failures                    *
**************************************************

1) Core Functionality (webpack 3.8.1) copes with a URL public path
  - file index.html should not include <link

2) Core Functionality (webpack 3.8.1) copes with a URL public path with specified css file
  - file index.html should not include <link

3) Custom css RegExp (webpack 3.8.1) copes with a URL public path
  - file index.html should not include <link

4) Custom css RegExp (webpack 3.8.1) copes with a URL public path with specified css file
  - file index.html should not include <link

5) Explicitly Setting Position (webpack 3.8.1) copes with a URL public path with specified css file
  - file index.html should not include <link
```

So I believe the tests are enough. If there is anything else you this is needed, I'm glad to help.

Best